### PR TITLE
fix(trans): storage translations

### DIFF
--- a/src/components/main/MainMenu.tsx
+++ b/src/components/main/MainMenu.tsx
@@ -68,7 +68,7 @@ const MainMenu = (): JSX.Element => {
           <DataUsageIcon />
         </ListItemIcon>
 
-        <ListItemText primary={t('MAIN_MENU_STOCKAGE')} />
+        <ListItemText primary={t('MAIN_MENU_STORAGE')} />
       </ListItemButton>
       {/* <ListItemButton
         button

--- a/src/components/main/StockageScreen.tsx
+++ b/src/components/main/StockageScreen.tsx
@@ -79,7 +79,7 @@ const StockageScreen = (): JSX.Element => {
               {/* { */}
               <Trans
                 t={t}
-                i18nKey="STORAGE_INFO"
+                i18nKey="STORAGE_TEXT"
                 values={{
                   email: ADMIN_CONTACT,
                 }}
@@ -90,7 +90,7 @@ const StockageScreen = (): JSX.Element => {
             </Typography>
 
             <Alert severity="info" sx={{ mt: 2, mb: 1 }}>
-              {t('STOCKAGE_INFO')}
+              {t('STORAGE_INFO')}
             </Alert>
           </Stack>
         </Stack>

--- a/src/langs/de.json
+++ b/src/langs/de.json
@@ -1,1 +1,44 @@
-{}
+{
+  "STORAGE_TITLE": "Speicher",
+  "STORAGE_TEXT": "Graasp bietet seinen Nutzern einen begrenzten kostenlosen Speicherplatz. In naher Zukunft werden Benutzerpläne verfügbar sein, um mehr Datenspeicher freizuschalten. Wenn Sie daran interessiert sind, lassen Sie es uns wissen, indem Sie <0>{{email}}</0> kontaktieren.",
+  "STORAGE_INFO": "Der Speicherplatz zählt alle hochgeladenen Dateien wie PDF, Bilder, Videos, Audio usw. Ordner, Apps und Graasp-Dokumente werden nicht gezählt.",
+
+  "CROP_IMAGE_MODAL_CONTENT_TEXT": "Schneiden Sie das ausgewählte Bild auf die erforderliche Größe zu.",
+  "CROP_IMAGE_MODAL_TITLE": "Bild beschneiden",
+  "CONFIRM_BUTTON": "Bestätigen",
+  "MAIN_MENU_PROFILE": "Profil",
+  "MAIN_MENU_AVATAR": "Avatar",
+  "MAIN_MENU_PASSWORD": "Passwort",
+  "MAIN_MENU_STORAGE": "Speicher",
+  "SAVE_ACTIONS_TOGGLE_TOOLTIP": "Demnächst verfügbar!",
+
+  "PROFILE_TITLE": "Profil",
+  "PROFILE_MEMBER_ID_TITLE": "Benützer ID",
+  "PROFILE_LANGUAGE_TITLE": "Sprache",
+  "PROFILE_CREATED_AT_TITLE": "Mitglied seit",
+  "PROFILE_EMAIL_TITLE": "Email",
+  "PROFILE_EMAIL_FREQUENCY_TITLE": "Email Frequenz",
+  "PROFILE_SAVE_ACTIONS_TITLE": "Analytik einschalten",
+  "PROFILE_DELETE_ACCOUNT_MODAL_TITLE": "Löschung bestätigen",
+  "PROFILE_DELETE_ACCOUNT_MODAL_INFORMATION": "Ihr Konto wird dauerhaft gelöscht.",
+  "PROFILE_DELETE_ACCOUNT_MODAL_CONFIRM_BUTTON": "Dauerhaft löschen",
+  "PROFILE_DELETE_ACCOUNT_MODAL_CANCEL_BUTTON": "Abbrechen",
+
+  "PROFILE_DELETE_ACCOUNT_TITLE": "Konto löschen",
+  "PROFILE_DELETE_ACCOUNT_BUTTON": "Konto löschen",
+  "PROFILE_DELETE_ACCOUNT_INFORMATION": "Die Löschung eines Kontos ist unwiderruflich. Bitte seien Sie vorsichtig.",
+
+  "PROFILE_AVATAR_TITLE": "Profil Bild",
+  "PROFILE_AVATAR_INFORMATION": "Profil Bild aktualisieren",
+  "PROFILE_AVATAR_CURRENT_ALT": "Profil Bild",
+
+  "PASSWORD_SETTINGS_TITLE": "Passwort ändern",
+  "PASSWORD_SETTINGS_CURRENT_LABEL": "Aktuelles Passwort",
+  "PASSWORD_SETTINGS_CURRENT_INFORMATION": "Lassen Sie dieses Feld leer, wenn Sie noch kein Passwort festgelegt haben.",
+  "PASSWORD_SETTINGS_NEW_LABEL": "Neues Passwort",
+  "PASSWORD_SETTINGS_NEW_CONFIRM_LABEL": "Passwort bestätigen",
+  "PASSWORD_SETTINGS_CONFIRM_BUTTON": "Password ändern",
+
+  "PASSWORD_SETTINGS_CONFIRM_INFORMATION": "Er muss aus mindestens 8 Zeichen bestehen, darunter eine Zahl, ein Kleinbuchstabe und ein Großbuchstabe.",
+  "PASSWORD_SETTINGS_REQUEST_RESET_BUTTON": "Reset anfordern"
+}

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -7,7 +7,7 @@
   "MAIN_MENU_PROFILE": "Profile",
   "MAIN_MENU_AVATAR": "Avatar",
   "MAIN_MENU_PASSWORD": "Password",
-  "MAIN_MENU_STOCKAGE": "Stockage",
+  "MAIN_MENU_STORAGE": "Storage",
   "SAVE_ACTIONS_TOGGLE_TOOLTIP": "Coming soon!",
 
   "PROFILE_TITLE": "Profile",

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -1,6 +1,8 @@
 {
-  "STORAGE_INFO": "Graasp provides a limited free storage for its users. In a near future, user plans will be available to unlock more data storage. If you are interested, let us know by contacting <0>{{email}}</0>.",
   "STORAGE_TITLE": "Storage",
+  "STORAGE_TEXT": "Graasp provides a limited free storage for its users. In a near future, user plans will be available to unlock more data storage. If you are interested, let us know by contacting <0>{{email}}</0>.",
+  "STORAGE_INFO": "Storage takes into account all uploaded files such as PDF, images, videos, audio, etc. Folders, apps and Graasp documents are not included.",
+
   "CROP_IMAGE_MODAL_CONTENT_TEXT": "Crop your chosen image to fit the image size requirements.",
   "CROP_IMAGE_MODAL_TITLE": "Crop Image",
   "CONFIRM_BUTTON": "Confirm",
@@ -38,7 +40,5 @@
   "PASSWORD_SETTINGS_CONFIRM_BUTTON": "Update password",
 
   "PASSWORD_SETTINGS_CONFIRM_INFORMATION": "Make sure it is at least 8 characters including a number, a lowercase letter and an uppercase letter.",
-  "PASSWORD_SETTINGS_REQUEST_RESET_BUTTON": "Request a reset",
-
-  "STOCKAGE_INFO": "Storage takes into account all uploaded files such as PDF, images, videos, audio, etc. Folders, apps and Graasp documents are not included."
+  "PASSWORD_SETTINGS_REQUEST_RESET_BUTTON": "Request a reset"
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -1,8 +1,11 @@
 {
-  "STORAGE_INFO": "Graasp offre un stockage gratuit limité à ces utilisateurs.Dans un futur proche, des abonnements seront disponibles pour débloquer plus de stockage. En cas d'intérêt, contactez-nous sur notre adresse <0>{{email}}</0>.",
   "STORAGE_TITLE": "Stockage",
+  "STORAGE_TEXT": "Graasp offre un stockage gratuit limité à ces utilisateurs.Dans un futur proche, des abonnements seront disponibles pour débloquer plus de stockage. En cas d'intérêt, contactez-nous sur notre adresse <0>{{email}}</0>.",
+  "STORAGE_INFO": "Le stockage comprend tous les fichiers téléversés comme des fichiers PDF, images, vidéos, audio, etc. Les dossiers, applications et les  documents Graasp ne sont pas inclus.",
+
   "CROP_IMAGE_MODAL_CONTENT_TEXT": "Couper l'image choisie pour correspondre aux critères de taille d'image.",
   "CROP_IMAGE_MODAL_TITLE": "Couper l'Image",
+
   "CONFIRM_BUTTON": "Confirmer",
   "MAIN_MENU_PROFILE": "Profil",
   "MAIN_MENU_AVATAR": "Avatar",
@@ -34,6 +37,5 @@
   "PASSWORD_SETTINGS_NEW_CONFIRM_LABEL": "Confirmer le mot de passe",
   "PASSWORD_SETTINGS_CONFIRM_BUTTON": "Changer le mot de passe",
   "PASSWORD_SETTINGS_CONFIRM_INFORMATION": "Le mot de passe doit au moins contenir 8 caractères dont un chiffre, une lettre minuscule et une lettre majuscule.",
-  "PASSWORD_SETTINGS_REQUEST_RESET_BUTTON": "Réinitialiser le mot de passe",
-  "STOCKAGE_INFO": "Le stockage comprend tous les fichiers téléversés comme des fichiers PDF, images, vidéos, audio, etc. Les dossiers, applications et les  documents Graasp ne sont pas inclus."
+  "PASSWORD_SETTINGS_REQUEST_RESET_BUTTON": "Réinitialiser le mot de passe"
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -7,7 +7,7 @@
   "MAIN_MENU_PROFILE": "Profil",
   "MAIN_MENU_AVATAR": "Avatar",
   "MAIN_MENU_PASSWORD": "Mot de Passe",
-  "MAIN_MENU_STOCKAGE": "Stockage",
+  "MAIN_MENU_STORAGE": "Stockage",
   "SAVE_ACTIONS_TOGGLE_TOOLTIP": "Prochainement !",
 
   "PROFILE_TITLE": "Profil",


### PR DESCRIPTION
In this PR I fix an inconsistancy in the translations for the storage list item. It said "Stockage" when it should be "Storage"
fix #47
