### PR TITLE
fix: avatar upload size error

### DIFF
--- a/cypress/fixtures/members.ts
+++ b/cypress/fixtures/members.ts
@@ -3,7 +3,7 @@ import { Member, MemberFactory, PublicProfile } from '@graasp/sdk';
 import { MemberForTest } from '../support/utils';
 import { AVATAR_LINK } from './thumbnails/links';
 
-export const CURRENT_MEMBER = MemberFactory();
+export const CURRENT_MEMBER = MemberFactory({ extra: { lang: 'en' } });
 export const BOB = MemberFactory({
   id: 'e1a0a49d-dfc4-466e-8379-f3846cda91e2',
   name: 'BOB',

--- a/src/components/main/CropModal.tsx
+++ b/src/components/main/CropModal.tsx
@@ -82,7 +82,7 @@ const CropModal = ({ onConfirm, onClose, src }: CropProps): JSX.Element => {
      * Compute the relative width and height
      * They express the size of the crop in terms of a relative portion of the original image.
      * For example if only the first quarter of the image was used in the crop,
-     * the relativeCrop would be 0.5, 0.5, meaning half of the height, abd half of the width
+     * the relativeCrop would be 0.5, 0.5, meaning half of the height, and half of the width
      */
     const relativeCrop = {
       width: completedCrop.width / image.width,

--- a/src/components/main/MemberCard.tsx
+++ b/src/components/main/MemberCard.tsx
@@ -74,6 +74,7 @@ const MemberCard = (): JSX.Element | null => {
   }
   const onThumbnailUpload = (payload: { avatar: Blob }) => {
     const { avatar } = payload;
+    console.log(avatar.size);
     if (!avatar) {
       return;
     }

--- a/src/components/main/MemberCard.tsx
+++ b/src/components/main/MemberCard.tsx
@@ -74,7 +74,6 @@ const MemberCard = (): JSX.Element | null => {
   }
   const onThumbnailUpload = (payload: { avatar: Blob }) => {
     const { avatar } = payload;
-    console.log(avatar.size);
     if (!avatar) {
       return;
     }


### PR DESCRIPTION
In this PR I fix an issue where the user avatar picture was artificially growing in size before being sent to the backend. This resulted in a silent error and failure to update the avatar picture. With this PR I update the code that handles cropping and creating a new image. It uses lossy compression to reduce the file size and ensure we do not hit the limit of 10Mb that we fixed for file uploads.

Maybe this component should be moved to UI alongside a custom hook to compute the image crop. @ReidyT were you working on that recently ? 