### PR TITLE
fix: remove page size option that exceeds the maximum allowed in storage table

### DIFF
--- a/src/components/main/MemberStorageFiles.tsx
+++ b/src/components/main/MemberStorageFiles.tsx
@@ -117,6 +117,7 @@ const MemberStorageFiles = (): JSX.Element | null => {
           onPageChange={(event, newPage) => handlePageChange(event, newPage)}
           rowsPerPage={pagination.pageSize}
           onRowsPerPageChange={handlePageSizeChange}
+          rowsPerPageOptions={[5, 10, 25, 50]}
         />
       </>
     );


### PR DESCRIPTION
Since the max page size is set to 50 in the backend so I deleted the select of 100 items
