### PR TITLE
feat: add umami plugin in vite config

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -35,8 +35,8 @@ jobs:
           VITE_GRAASP_ANALYTICS_HOST: ${{ vars.VITE_GRAASP_ANALYZER_HOST }}
           VITE_SENTRY_ENV: ${{ vars.VITE_SENTRY_ENV }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-          # VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
           VITE_SHOW_NOTIFICATIONS: ${{ vars.VITE_SHOW_NOTIFICATIONS }}
+          UMAMI_WEBSITE_ID: ${{ secrets.UMAMI_WEBSITE_ID }}
         run: pnpm build
         shell: bash
 
@@ -44,7 +44,7 @@ jobs:
         uses: graasp/graasp-deploy/.github/actions/deploy-s3@v1
         # Replace input build-folder or version if needed
         with:
-          build-folder: 'build'
+          build-folder: "build"
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
           aws-region: ${{ secrets.AWS_REGION_DEV }}
           aws-s3-bucket-name: ${{ secrets.AWS_S3_BUCKET_NAME_GRAASP_ACCOUNT_DEV }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,8 +38,8 @@ jobs:
           VITE_GRAASP_ANALYTICS_HOST: ${{ vars.VITE_GRAASP_ANALYZER_HOST }}
           VITE_SENTRY_ENV: ${{ vars.VITE_SENTRY_ENV }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
           VITE_SHOW_NOTIFICATIONS: ${{ vars.VITE_SHOW_NOTIFICATIONS }}
+          UMAMI_WEBSITE_ID: ${{ secrets.UMAMI_WEBSITE_ID }}
         run: pnpm build
         shell: bash
 
@@ -47,7 +47,7 @@ jobs:
         uses: graasp/graasp-deploy/.github/actions/deploy-s3@v1
         # Replace input build-folder or version if needed
         with:
-          build-folder: 'build'
+          build-folder: "build"
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
           aws-region: ${{ secrets.AWS_REGION_PROD }}
           aws-s3-bucket-name: ${{ secrets.AWS_S3_BUCKET_NAME_GRAASP_ACCOUNT }}

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -39,6 +39,7 @@ jobs:
           VITE_SENTRY_ENV: ${{ vars.VITE_SENTRY_ENV }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_SHOW_NOTIFICATIONS: ${{ vars.VITE_SHOW_NOTIFICATIONS }}
+          UMAMI_WEBSITE_ID: ${{ secrets.UMAMI_WEBSITE_ID }}
         run: pnpm build
         shell: bash
 
@@ -46,7 +47,7 @@ jobs:
         uses: graasp/graasp-deploy/.github/actions/deploy-s3@v1
         # Replace input build-folder or version if needed
         with:
-          build-folder: 'build'
+          build-folder: "build"
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGE }}
           aws-region: ${{ secrets.AWS_REGION_STAGE }}
           aws-s3-bucket-name: ${{ secrets.AWS_S3_BUCKET_NAME_GRAASP_ACCOUNT_STAGE }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Graasp Account
 
-[![GitHub Release](https://img.shields.io/github/release/graasp/graasp-library)]()
+[![GitHub Release](https://img.shields.io/github/release/graasp/graasp-library)](https://github.com/graasp-account/releases)
 ![typescript version](https://img.shields.io/github/package-json/dependency-version/graasp/graasp-library/dev/typescript)
 [![gitlocalized](https://gitlocalize.com/repo/8978/whole_project/badge.svg)](https://gitlocalize.com/repo/8978?utm_source=badge)
 
@@ -11,4 +11,6 @@ VITE_PORT=3114
 VITE_GRAASP_API_HOST=http://localhost:3000
 VITE_GRAASP_AUTH_HOST=http://localhost:3001
 VITE_SHOW_NOTIFICATIONS=true
+
+UMAMI_WEBSITE_ID=<the id of your umami project>
 ```

--- a/umami.plugin.ts
+++ b/umami.plugin.ts
@@ -1,0 +1,62 @@
+import type { Plugin, ResolvedConfig } from 'vite';
+
+export interface UmamiPluginOptions {
+  /**
+   * The ID of the project Clarity provides to you.
+   *
+   * Can be found in the URL of your project.
+   *
+   * @example `k4vhy94oj3`
+   */
+  websiteId: string;
+
+  /**
+   * Host where the script is hosted
+   * @default "https://cloud.umami.is"
+   */
+  host?: string;
+
+  /**
+   * Whether to inject the script in development mode.
+   *
+   * @default false
+   */
+  enableInDevMode?: boolean;
+}
+
+export default function umamiPlugin(options: UmamiPluginOptions): Plugin {
+  let config: ResolvedConfig;
+  return {
+    name: 'umami-script',
+    enforce: 'pre',
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
+    transformIndexHtml() {
+      if (config.command === 'serve' && !options.enableInDevMode) {
+        return [];
+      }
+
+      if (!options.websiteId) {
+        throw new Error(
+          '[umami-script] No website id provided. Please provide a website id.',
+        );
+      }
+      const src = `${options.host ?? 'https://cloud.umami.is'}/script.js`;
+
+      return [
+        {
+          tag: 'script',
+          attrs: {
+            defer: true,
+            crossorigin: true,
+            src,
+            'data-website-id': options.websiteId,
+          },
+          children: '',
+          injectTo: 'head',
+        },
+      ];
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,11 @@
 /// <reference types="./src/env.d.ts"/>
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
-// import { visualizer } from 'rollup-plugin-visualizer';
 import { UserConfigExport, defineConfig, loadEnv } from 'vite';
 import checker from 'vite-plugin-checker';
 import istanbul from 'vite-plugin-istanbul';
+
+import umamiPlugin from './umami.plugin';
 
 // https://vitejs.dev/config/
 const config = ({ mode }: { mode: string }): UserConfigExport => {
@@ -16,49 +17,56 @@ const config = ({ mode }: { mode: string }): UserConfigExport => {
     ...loadEnv(mode, process.cwd()),
   };
 
+  const { VITE_PORT, BROWSER, UMAMI_WEBSITE_ID } = process.env;
+  // compute the port to use
+  const PORT = parseInt(VITE_PORT || '3114', 10);
+
+  // compute whether we should open the browser
+  // this defines if we should automatically open the browser
+  const shouldOpen = BROWSER && BROWSER !== 'none';
+
   return defineConfig({
     base: '/',
     server: {
-      port: parseInt(process.env.VITE_PORT || '3114', 10),
-      // only auto open the app when in dev mode
-      open: mode === 'dev',
+      port: PORT,
+      // whether we should open the url on start
+      open: shouldOpen,
       watch: {
         ignored: ['**/coverage/**', '**/cypress/downloads/**'],
       },
     },
     preview: {
-      port: parseInt(process.env.VITE_PORT || '3333', 10),
+      port: PORT,
+      // forces to use the specified port
       strictPort: true,
     },
     build: {
       outDir: 'build',
     },
     plugins: [
-      checker({
-        typescript: true,
-        eslint: { lintCommand: 'eslint "./**/*.{ts,tsx}"' },
-        overlay: { initialIsOpen: false },
-      }),
+      // the checker plugin is disabled when running the tests
+      mode !== 'test'
+        ? checker({
+            typescript: true,
+            eslint: { lintCommand: 'eslint "./**/*.{ts,tsx}"' },
+            overlay: { initialIsOpen: false },
+          })
+        : undefined,
       react(),
       istanbul({
         include: 'src/*',
         exclude: ['node_modules', 'test/', '.nyc_output', 'coverage'],
         extension: ['.js', '.ts', '.tsx'],
         requireEnv: false,
+        // forces to instrument code also in production build only if the mode is test
+        // this is useful when we want to build and preview in CI to have faster and more stable tests
         forceBuildInstrument: mode === 'test',
         checkProd: true,
       }),
-      //   ...(mode === 'development'
-      //     ? [
-      //         visualizer({
-      //           template: 'treemap', // or sunburst
-      //           open: true,
-      //           gzipSize: true,
-      //           brotliSize: true,
-      //           filename: 'bundle_analysis.html',
-      //         }) as PluginOption,
-      //       ]
-      //     : []),
+      // only include umami script when the WEBSITE_ID is set
+      UMAMI_WEBSITE_ID
+        ? umamiPlugin({ websiteId: UMAMI_WEBSITE_ID })
+        : undefined,
     ],
     resolve: {
       alias: {


### PR DESCRIPTION
In this PR I add a custom vite plugin that inserts the umami script tag into the html output file if the `UMAMI_WEBSITE_ID` env variable is set. 

This removes the error that the builder has when the variable is not set. It was also a nice experience to see how it is possible to manipulate the outputted HTML code in vite !