### PR TITLE
fix: use package.json defined node version in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: "package.json"
           cache: "pnpm"
 
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: "package.json"
           cache: "pnpm"
 
       #  use the Cypress GitHub Action to run Cypress tests within the chrome browser


### PR DESCRIPTION
In this PR:
- use the specified node version from `package.json` for setting up node in the CI.

close #385 