### PR TITLE
fix: updated lang is not shown in preferences when switching lang

### DIFF
--- a/cypress/e2e/settings/preferences.cy.ts
+++ b/cypress/e2e/settings/preferences.cy.ts
@@ -126,6 +126,11 @@ describe('Edit preferences', () => {
 
       const newLang = 'de';
       switchLanguage(newLang);
+      // Ensure the selected language is shown as the select value
+      cy.get(`#${PREFERENCES_LANGUAGE_SWITCH_ID}`).should(
+        'contain.text',
+        langs[newLang],
+      );
 
       cy.get(`#${PREFERENCES_SAVE_BUTTON_ID}`).click();
       cy.wait('@editMember').then(({ request }) => {

--- a/src/components/main/EditMemberPreferences.tsx
+++ b/src/components/main/EditMemberPreferences.tsx
@@ -70,7 +70,7 @@ const EditMemberPreferences = ({
     >
       <FormProperty title={t('PROFILE_LANGUAGE_TITLE')}>
         <LanguageSwitch
-          lang={member.extra?.lang ?? DEFAULT_LANG}
+          lang={selectedLang}
           id={PREFERENCES_LANGUAGE_SWITCH_ID}
           onChange={setSelectedLang}
         />


### PR DESCRIPTION
In this PR: show the right language in the switch when editing the member language.

Previously it was staying on the current language.
It now changes to show the selected language when the select closes.